### PR TITLE
Switch interpreter to bash instead of sh

### DIFF
--- a/Yet-another-dracula/dracula-tela-icon-patch.sh
+++ b/Yet-another-dracula/dracula-tela-icon-patch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ### PATH
 readonly ICONS="$HOME/.local/share/icons"
 readonly PATCH_PATHS=(


### PR DESCRIPTION
Hi! Currently Dracula-izing some things in KDE, and ran across this repo - thanks!

Was just trying ti run this script on the Tela icons, and I get a syntax error using sh, which doesn't happen though if I use bash instead. Same issue [described here](https://unix.stackexchange.com/questions/45781/shell-script-fails-syntax-error-unexpected).